### PR TITLE
Arena-based KV memory isolation

### DIFF
--- a/deps/jemalloc/src/jemalloc.c
+++ b/deps/jemalloc/src/jemalloc.c
@@ -4533,6 +4533,74 @@ realloc_with_usize(void *ptr, size_t size, size_t *old_usize, size_t *new_usize)
 	return je_realloc_internal(ptr, size, old_usize, new_usize);
 }
 
+JEMALLOC_EXPORT JEMALLOC_ALLOCATOR JEMALLOC_RESTRICT_RETURN
+void JEMALLOC_NOTHROW *
+JEMALLOC_ATTR(malloc) JEMALLOC_ALLOC_SIZE(1)
+mallocx_with_usize(size_t size, int flags, size_t *usize) {
+	void *ret;
+	static_opts_t sopts;
+	dynamic_opts_t dopts;
+
+	LOG("core.mallocx_with_usize.entry", "size: %zu, flags: %d", size, flags);
+
+	static_opts_init(&sopts);
+	dynamic_opts_init(&dopts);
+
+	sopts.assert_nonempty_alloc = true;
+	sopts.null_out_result_on_error = true;
+	sopts.oom_string = "<jemalloc>: Error in mallocx(): out of memory\n";
+
+	dopts.result = &ret;
+	dopts.num_items = 1;
+	dopts.item_size = size;
+	if (flags != 0) {
+		dopts.alignment = MALLOCX_ALIGN_GET(flags);
+		dopts.zero = MALLOCX_ZERO_GET(flags);
+		dopts.tcache_ind = mallocx_tcache_get(flags);
+		dopts.arena_ind = mallocx_arena_get(flags);
+	}
+
+	imalloc(&sopts, &dopts);
+	if (sopts.slow) {
+		uintptr_t args[3] = {size, flags};
+		hook_invoke_alloc(hook_alloc_mallocx, ret, (uintptr_t)ret,
+		    args);
+	}
+
+	LOG("core.mallocx_with_usize.exit", "result: %p", ret);
+	if (usize) *usize = dopts.usize;
+	return ret;
+}
+
+JEMALLOC_EXPORT void JEMALLOC_NOTHROW
+dallocx_with_usize(void *ptr, int flags, size_t *usize) {
+	LOG("core.dallocx_with_usize.entry", "ptr: %p, flags: %d", ptr, flags);
+
+	assert(ptr != NULL);
+	assert(malloc_initialized() || IS_INITIALIZER);
+
+	tsd_t *tsd = tsd_fetch_min();
+	bool fast = tsd_fast(tsd);
+	check_entry_exit_locking(tsd_tsdn(tsd));
+
+	unsigned tcache_ind = mallocx_tcache_get(flags);
+	tcache_t *tcache = tcache_get_from_ind(tsd, tcache_ind, !fast,
+	    /* is_alloc */ false);
+
+	UTRACE(ptr, 0, 0);
+	if (likely(fast)) {
+		tsd_assert_fast(tsd);
+		ifree(tsd, ptr, tcache, false, usize);
+	} else {
+		uintptr_t args_raw[3] = {(uintptr_t)ptr, flags};
+		hook_invoke_dalloc(hook_dalloc_dallocx, ptr, args_raw);
+		ifree(tsd, ptr, tcache, true, usize);
+	}
+	check_entry_exit_locking(tsd_tsdn(tsd));
+
+	LOG("core.dallocx_with_usize.exit", "");
+}
+
 JEMALLOC_EXPORT void JEMALLOC_NOTHROW
 free_with_usize(void *ptr, size_t *usize) {
 	je_free_internal(ptr, usize);

--- a/src/evict.c
+++ b/src/evict.c
@@ -569,6 +569,7 @@ int performEvictions(void) {
         static unsigned int next_db = 0;
         sds bestkey = NULL;
         int bestdbid;
+        int bestslot = -1;
         redisDb *db;
         dictEntry *de;
 
@@ -640,6 +641,7 @@ int performEvictions(void) {
                      * a ghost and we need to try the next element. */
                     if (de) {
                         bestkey = kvobjGetKey(dictGetKV(de));
+                        bestslot = pool[k].slot;
                         break;
                     } else {
                         /* Ghost... Iterate again. */
@@ -671,6 +673,7 @@ int performEvictions(void) {
                     kvobj *kv = dictGetKV(de);
                     bestkey = kvobjGetKey(kv);
                     bestdbid = j;
+                    bestslot = slot;
                     break;
                 }
             }
@@ -681,6 +684,11 @@ int performEvictions(void) {
             long long key_mem_freed;
             db = server.db+bestdbid;
 
+#if defined(USE_JEMALLOC)
+            /* Switch to the KV arena for this slot so that freeing the
+             * evicted key's memory goes back to the correct arena/tcache. */
+            if (bestslot >= 0) kvArenaSwitchToSlot(bestslot);
+#endif
             enterExecutionUnit(1, 0);
             robj *keyobj = createStringObject(bestkey,sdslen(bestkey));
             deleteEvictedKeyAndPropagate(db, keyobj, &key_mem_freed);
@@ -688,6 +696,9 @@ int performEvictions(void) {
             exitExecutionUnit();
             /* Propagate the DEL command */
             postExecutionUnitOperations();
+#if defined(USE_JEMALLOC)
+            if (bestslot >= 0) kvArenaRestore();
+#endif
 
             mem_freed += key_mem_freed;
             keys_freed++;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1648,6 +1648,17 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
      * This releases physical pages incrementally, reducing COW overhead. */
     if (server.in_fork_child) {
         int num_slots = kvstoreNumDicts(db->keys);
+
+        /* Start a background worker thread to asynchronously free dicts
+         * and purge arenas while the main thread continues serializing. */
+        ArenaFreeQueue afq;
+        pthread_t free_worker;
+        kvArenaFreeQueueInit(&afq, db->keys, num_slots);
+        if (pthread_create(&free_worker, NULL, kvArenaFreeWorker, &afq) != 0) {
+            serverLog(LL_WARNING, "Failed to create arena free worker thread");
+            return -1;
+        }
+
         for (int arena_idx = 0; arena_idx < KV_ARENA_COUNT; arena_idx++) {
             for (int slot = arena_idx; slot < num_slots; slot += KV_ARENA_COUNT) {
                 if (kvstoreDictSize(db->keys, slot) == 0) continue;
@@ -1697,19 +1708,14 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
                 }
                 kvstoreResetDictIterator(&kvs_di);
             }
-            /* All slots for this arena are dumped. Now batch-free all keys
-             * to mark arena pages as dirty, then purge to release them.
-             * Switch to the KV arena+tcache first so that dallocx routes
-             * freed objects into the correct tcache, allowing purge to
-             * reclaim the physical pages effectively. */
-            kvArenaSwitchToSlot(arena_idx);
-            for (int slot = arena_idx; slot < num_slots; slot += KV_ARENA_COUNT) {
-                dict *d = kvstoreGetDict(db->keys, slot);
-                if (d) dictEmpty(d, NULL);
-            }
-            kvArenaRestore();
-            kvArenaPurge(arena_idx);
+            /* All slots for this arena are serialized. Push the arena
+             * index to the background worker for async dictEmpty + purge. */
+            kvArenaFreeQueuePush(&afq, arena_idx);
         }
+
+        /* Signal the worker to exit and wait for it to finish. */
+        kvArenaFreeQueueStop(&afq);
+        pthread_join(free_worker, NULL);
         return written;
     }
 #endif

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1642,6 +1642,79 @@ ssize_t rdbSaveDb(rio *rdb, int dbid, int rdbflags, long *key_counter, unsigned 
     if ((res = rdbSaveLen(rdb,expires_size)) < 0) goto werr;
     written += res;
 
+#if defined(USE_JEMALLOC)
+    /* In fork child process, iterate by arena group so we can free keys
+     * and purge each arena immediately after its slots are dumped.
+     * This releases physical pages incrementally, reducing COW overhead. */
+    if (server.in_fork_child) {
+        int num_slots = kvstoreNumDicts(db->keys);
+        for (int arena_idx = 0; arena_idx < KV_ARENA_COUNT; arena_idx++) {
+            for (int slot = arena_idx; slot < num_slots; slot += KV_ARENA_COUNT) {
+                if (kvstoreDictSize(db->keys, slot) == 0) continue;
+
+                /* Skip slots that are being trimmed */
+                if (server.cluster_enabled && isSlotInTrimJob(slot)) {
+                    *skipped += kvstoreDictSize(db->keys, slot);
+                    continue;
+                }
+
+                /* Save slot info. */
+                if (server.cluster_enabled) {
+                    if ((res = rdbSaveType(rdb, RDB_OPCODE_SLOT_INFO)) < 0) goto werr;
+                    written += res;
+                    if ((res = rdbSaveLen(rdb, slot)) < 0) goto werr;
+                    written += res;
+                    if ((res = rdbSaveLen(rdb, kvstoreDictSize(db->keys, slot))) < 0) goto werr;
+                    written += res;
+                    if ((res = rdbSaveLen(rdb, kvstoreDictSize(db->expires, slot))) < 0) goto werr;
+                    written += res;
+                }
+
+                /* Dump all keys in this slot (read-only, no COW from child). */
+                kvstoreDictIterator kvs_di;
+                kvstoreInitDictIterator(&kvs_di, db->keys, slot);
+                while ((de = kvstoreDictIteratorNext(&kvs_di)) != NULL) {
+                    kvobj *kv = dictGetKV(de);
+                    robj key;
+                    long long expire;
+
+                    initStaticStringObject(key, kvobjGetKey(kv));
+                    expire = kvobjGetExpire(kv);
+                    res = rdbSaveKeyValuePair(rdb, &key, kv, expire, dbid);
+                    if (res < 0) {
+                        kvstoreResetDictIterator(&kvs_di);
+                        goto werr;
+                    }
+                    written += res;
+
+                    if (((*key_counter)++ & 1023) == 0) {
+                        long long now = mstime();
+                        if (now - info_updated_time >= 1000) {
+                            sendChildInfo(CHILD_INFO_TYPE_CURRENT_INFO, *key_counter, pname);
+                            info_updated_time = now;
+                        }
+                    }
+                }
+                kvstoreResetDictIterator(&kvs_di);
+            }
+            /* All slots for this arena are dumped. Now batch-free all keys
+             * to mark arena pages as dirty, then purge to release them.
+             * Switch to the KV arena+tcache first so that dallocx routes
+             * freed objects into the correct tcache, allowing purge to
+             * reclaim the physical pages effectively. */
+            kvArenaSwitchToSlot(arena_idx);
+            for (int slot = arena_idx; slot < num_slots; slot += KV_ARENA_COUNT) {
+                dict *d = kvstoreGetDict(db->keys, slot);
+                if (d) dictEmpty(d, NULL);
+            }
+            kvArenaRestore();
+            kvArenaPurge(arena_idx);
+        }
+        return written;
+    }
+#endif
+
+    /* Normal path: sequential iteration (non-fork or no jemalloc). */
     kvstoreIteratorInit(&kvs_it, db->keys);
     int last_slot = -1;
     /* Iterate this DB writing every entry */
@@ -3716,6 +3789,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
     int error;
     long long empty_keys_skipped = 0;
 
+#if defined(USE_JEMALLOC)
+    int current_slot = -1; /* Track slot for arena switching during load. */
+    int saved_arena_flags = zmalloc_arena_flags;
+#endif
+
     rdb->update_cksum = rdbLoadProgressCallback;
     rdb->max_processing_chunk = server.loading_process_events_interval_bytes;
     if (rioRead(rdb,buf,9) == 0) goto eoferr;
@@ -3811,6 +3889,12 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             kvstoreDictExpand(db->keys, slot_id, slot_size);
             kvstoreDictExpand(db->expires, slot_id, expires_slot_size);
             should_expand_db = 0;
+#if defined(USE_JEMALLOC)
+            /* Switch to the KV arena for this slot so that subsequent
+             * key/value allocations land in the correct arena. */
+            current_slot = (int)slot_id;
+            kvArenaSwitchToSlot(current_slot);
+#endif
             continue; /* Read next opcode. */
         } else if (type == RDB_OPCODE_AUX) {
             /* AUX: generic string-string fields. Use to add state to RDB
@@ -3961,6 +4045,15 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             keyMetaSpecCleanup(&keyMeta);
             goto eoferr;
         }
+#if defined(USE_JEMALLOC)
+        /* If no SLOT_INFO marker was seen (non-cluster or legacy RDB),
+         * compute the slot from the key name and switch arena before
+         * loading the value (which is the bulk of memory). */
+        if (current_slot < 0) {
+            int slot = getKeySlot(key);
+            kvArenaSwitchToSlot(slot);
+        }
+#endif
         /* Read value */
         val = rdbLoadObject(type,rdb,key,db->id,&error);
 
@@ -4087,6 +4180,11 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             }
         }
     }
+
+#if defined(USE_JEMALLOC)
+    /* Restore arena flags to whatever they were before loading. */
+    zmalloc_arena_flags = saved_arena_flags;
+#endif
 
     if (empty_keys_skipped) {
         serverLog(LL_NOTICE,

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -4051,15 +4051,6 @@ int rdbLoadRioWithLoadingCtx(rio *rdb, int rdbflags, rdbSaveInfo *rsi, rdbLoadin
             keyMetaSpecCleanup(&keyMeta);
             goto eoferr;
         }
-#if defined(USE_JEMALLOC)
-        /* If no SLOT_INFO marker was seen (non-cluster or legacy RDB),
-         * compute the slot from the key name and switch arena before
-         * loading the value (which is the bulk of memory). */
-        if (current_slot < 0) {
-            int slot = getKeySlot(key);
-            kvArenaSwitchToSlot(slot);
-        }
-#endif
         /* Read value */
         val = rdbLoadObject(type,rdb,key,db->id,&error);
 

--- a/src/server.c
+++ b/src/server.c
@@ -7568,6 +7568,56 @@ void kvArenaPurge(int arena_idx) {
     je_mallctl(buf, NULL, NULL, NULL, 0);
 }
 
+/* ---- Async arena free queue (SPSC ring buffer) for child process ---- */
+
+void kvArenaFreeQueueInit(ArenaFreeQueue *q, kvstore *keys, int num_slots) {
+    memset(q, 0, sizeof(*q));
+    q->keys = keys;
+    q->num_slots = num_slots;
+}
+
+void kvArenaFreeQueuePush(ArenaFreeQueue *q, int arena_idx) {
+    int tail;
+    atomicGet(q->tail, tail);
+    q->tasks[tail] = arena_idx;
+    atomicSetWithSync(q->tail, (tail + 1) % (KV_ARENA_COUNT + 1));
+}
+
+void kvArenaFreeQueueStop(ArenaFreeQueue *q) {
+    atomicSetWithSync(q->stop, 1);
+}
+
+void *kvArenaFreeWorker(void *arg) {
+    ArenaFreeQueue *q = arg;
+
+    while (1) {
+        int head, tail, stop;
+        atomicGet(q->head, head);
+        atomicGetWithSync(q->tail, tail);
+
+        if (head == tail) {
+            /* Queue empty – check if we should exit. */
+            atomicGetWithSync(q->stop, stop);
+            if (stop) break;
+            usleep(100);
+            continue;
+        }
+
+        int arena_idx = q->tasks[head];
+        atomicSetWithSync(q->head, (head + 1) % (KV_ARENA_COUNT + 1));
+
+        /* Switch this thread's TLS so dallocx routes to the correct arena. */
+        kvArenaSwitchToSlot(arena_idx);
+        for (int slot = arena_idx; slot < q->num_slots; slot += KV_ARENA_COUNT) {
+            dict *d = kvstoreGetDict(q->keys, slot);
+            if (d) dictEmpty(d, NULL);
+        }
+        kvArenaRestore();
+        kvArenaPurge(arena_idx);
+    }
+    return NULL;
+}
+
 #endif /* USE_JEMALLOC */
 
 void memtest(size_t megabytes, int passes);

--- a/src/server.c
+++ b/src/server.c
@@ -7610,7 +7610,7 @@ void *kvArenaFreeWorker(void *arg) {
         kvArenaSwitchToSlot(arena_idx);
         for (int slot = arena_idx; slot < q->num_slots; slot += KV_ARENA_COUNT) {
             dict *d = kvstoreGetDict(q->keys, slot);
-            if (d) dictEmpty(d, NULL);
+            if (d) dictRelease(d);
         }
         kvArenaRestore();
         kvArenaPurge(arena_idx);

--- a/src/server.c
+++ b/src/server.c
@@ -3109,6 +3109,9 @@ void initServer(void) {
         server.maxmemory_policy = MAXMEMORY_NO_EVICTION;
     }
 
+#if defined(USE_JEMALLOC)
+    kvArenaInit();
+#endif
     luaEnvInit();
     scriptingInit(1);
     if (functionsInit() == C_ERR) {
@@ -3923,7 +3926,21 @@ void call(client *c, int flags) {
      * re-processing and unblock the client.*/
     c->flags |= CLIENT_EXECUTING_COMMAND;
 
+#if defined(USE_JEMALLOC)
+    /* Switch to the KV arena+tcache for this slot so that all allocations
+     * during command execution land in the correct arena. */
+    int old_arena_flags = zmalloc_arena_flags;
+    if (c->slot >= 0) {
+        kvArenaSwitchToSlot(c->slot);
+    }
+#endif
+
     c->cmd->proc(c);
+
+#if defined(USE_JEMALLOC)
+    /* Restore previous arena flags (usually 0 = default malloc path). */
+    zmalloc_arena_flags = old_arena_flags;
+#endif
 
     exitExecutionUnit();
 
@@ -7490,6 +7507,68 @@ void dismissMemoryInChild(void) {
     }
 #endif
 }
+
+/***************************************/
+/*** Arena-based KV memory isolation ***/
+/***************************************/
+
+#if defined(USE_JEMALLOC)
+
+static unsigned kv_arenas[KV_ARENA_COUNT];
+static unsigned kv_tcaches[KV_ARENA_COUNT];
+/* Pre-computed mallocx flags: MALLOCX_ARENA(a) | MALLOCX_TCACHE(t) */
+static int kv_arena_flags[KV_ARENA_COUNT];
+
+/* Create 16 kv_arenas + 16 independent tcaches for slot data isolation.
+ * Each arena gets its own tcache so cached objects never leak across arenas. */
+void kvArenaInit(void) {
+    for (int i = 0; i < KV_ARENA_COUNT; i++) {
+        unsigned arena;
+        size_t sz = sizeof(unsigned);
+        int err = je_mallctl("arenas.create", (void *)&arena, &sz, NULL, 0);
+        if (err) {
+            serverLog(LL_WARNING, "Failed creating KV jemalloc arena %d (err=%d).", i, err);
+            exit(1);
+        }
+        kv_arenas[i] = arena;
+
+        unsigned tcache;
+        sz = sizeof(unsigned);
+        err = je_mallctl("tcache.create", (void *)&tcache, &sz, NULL, 0);
+        if (err) {
+            serverLog(LL_WARNING, "Failed creating KV jemalloc tcache %d (err=%d).", i, err);
+            exit(1);
+        }
+        kv_tcaches[i] = tcache;
+        kv_arena_flags[i] = MALLOCX_ARENA(arena) | MALLOCX_TCACHE(tcache);
+    }
+
+    serverLog(LL_NOTICE, "KV arena isolation enabled: arenas[0..15]=%u..%u, tcaches[0..15]=%u..%u",
+              kv_arenas[0], kv_arenas[KV_ARENA_COUNT - 1],
+              kv_tcaches[0], kv_tcaches[KV_ARENA_COUNT - 1]);
+}
+
+/* Switch to the KV arena+tcache for this slot.
+ * Sets the thread-local zmalloc_arena_flags so that zmalloc/zcalloc/zrealloc
+ * route through mallocx with the correct arena and tcache. */
+void kvArenaSwitchToSlot(int slot) {
+    zmalloc_arena_flags = kv_arena_flags[slot % KV_ARENA_COUNT];
+}
+
+/* Restore to default allocation path (standard malloc, no arena routing). */
+void kvArenaRestore(void) {
+    zmalloc_arena_flags = 0;
+}
+
+/* Purge (madvise MADV_DONTNEED) freed pages in the given KV arena.
+ * arena_idx is 0..KV_ARENA_COUNT-1. */
+void kvArenaPurge(int arena_idx) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "arena.%u.purge", kv_arenas[arena_idx]);
+    je_mallctl(buf, NULL, NULL, NULL, 0);
+}
+
+#endif /* USE_JEMALLOC */
 
 void memtest(size_t megabytes, int passes);
 

--- a/src/server.h
+++ b/src/server.h
@@ -4498,6 +4498,17 @@ static inline const char *redactLogCstr(const char *s) {
 
 int iAmMaster(void);
 
+/* Arena-based KV memory isolation for reducing COW overhead in child processes.
+ * Uses je_mallctl("thread.arena") to switch the thread's default arena,
+ * preserving jemalloc's malloc() fast path (tcache). */
+#if defined(USE_JEMALLOC)
+#define KV_ARENA_COUNT 16
+void kvArenaInit(void);
+void kvArenaSwitchToSlot(int slot);
+void kvArenaRestore(void);
+void kvArenaPurge(int arena_idx);
+#endif
+
 #define STRINGIFY_(x) #x
 #define STRINGIFY(x) STRINGIFY_(x)
 

--- a/src/server.h
+++ b/src/server.h
@@ -4507,6 +4507,23 @@ void kvArenaInit(void);
 void kvArenaSwitchToSlot(int slot);
 void kvArenaRestore(void);
 void kvArenaPurge(int arena_idx);
+
+/* SPSC (Single-Producer Single-Consumer) ring buffer for async arena free.
+ * The RDB child main thread pushes completed arena indices; a background
+ * worker thread pops them and performs dictEmpty + kvArenaPurge. */
+typedef struct {
+    int tasks[KV_ARENA_COUNT + 1]; /* Ring buffer slots */
+    redisAtomic int head;          /* Consumer (worker) read index */
+    redisAtomic int tail;          /* Producer (main) write index */
+    redisAtomic int stop;          /* Set to 1 by producer to signal exit */
+    kvstore *keys;                 /* The DB keyspace to free from */
+    int num_slots;                 /* Total number of hash slots */
+} ArenaFreeQueue;
+
+void kvArenaFreeQueueInit(ArenaFreeQueue *q, kvstore *keys, int num_slots);
+void kvArenaFreeQueuePush(ArenaFreeQueue *q, int arena_idx);
+void kvArenaFreeQueueStop(ArenaFreeQueue *q);
+void *kvArenaFreeWorker(void *arg);
 #endif
 
 #define STRINGIFY_(x) #x

--- a/src/server.h
+++ b/src/server.h
@@ -4502,7 +4502,7 @@ int iAmMaster(void);
  * Uses je_mallctl("thread.arena") to switch the thread's default arena,
  * preserving jemalloc's malloc() fast path (tcache). */
 #if defined(USE_JEMALLOC)
-#define KV_ARENA_COUNT 16
+#define KV_ARENA_COUNT 8
 void kvArenaInit(void);
 void kvArenaSwitchToSlot(int slot);
 void kvArenaRestore(void);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -158,6 +158,10 @@ static void zmalloc_default_oom(size_t size) {
 
 static void (*zmalloc_oom_handler)(size_t) = zmalloc_default_oom;
 
+#if defined(USE_JEMALLOC)
+__thread int zmalloc_arena_flags = 0;
+#endif
+
 #ifdef HAVE_MALLOC_SIZE
 void *extend_to_usable(void *ptr, size_t size) {
     UNUSED(size);
@@ -170,6 +174,16 @@ void *extend_to_usable(void *ptr, size_t size) {
 static inline void *ztrymalloc_usable_internal(size_t size, size_t *usable) {
     /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
     if (size >= SIZE_MAX/2) return NULL;
+#if defined(USE_JEMALLOC)
+    if (zmalloc_arena_flags) {
+        void *ptr = mallocx(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, zmalloc_arena_flags);
+        if (!ptr) return NULL;
+        size = zmalloc_size(ptr);
+        update_zmalloc_stat_alloc(size);
+        if (usable) *usable = size;
+        return ptr;
+    }
+#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
     void *ptr = malloc_with_usize(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, &size);
 #else
@@ -301,6 +315,16 @@ void zfree_no_tcache(void *ptr) {
 static inline void *ztrycalloc_usable_internal(size_t size, size_t *usable) {
     /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
     if (size >= SIZE_MAX/2) return NULL;
+#if defined(USE_JEMALLOC)
+    if (zmalloc_arena_flags) {
+        void *ptr = mallocx(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, zmalloc_arena_flags | MALLOCX_ZERO);
+        if (!ptr) return NULL;
+        size = zmalloc_size(ptr);
+        update_zmalloc_stat_alloc(size);
+        if (usable) *usable = size;
+        return ptr;
+    }
+#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
     void *ptr = calloc_with_usize(1, MALLOC_MIN_SIZE(size)+PREFIX_SIZE, &size);
 #else
@@ -409,6 +433,23 @@ static inline void *ztryrealloc_usable_internal(void *ptr, size_t size, size_t *
         *old_usable = oldsize;
         return NULL;
     }
+#if defined(USE_JEMALLOC)
+    if (zmalloc_arena_flags) {
+        oldsize = zmalloc_size(ptr);
+        newptr = rallocx(ptr, size, zmalloc_arena_flags);
+        if (newptr == NULL) {
+            *usable = 0;
+            *old_usable = oldsize;
+            return NULL;
+        }
+        update_zmalloc_stat_free(oldsize);
+        size = zmalloc_size(newptr);
+        update_zmalloc_stat_alloc(size);
+        *usable = size;
+        *old_usable = oldsize;
+        return newptr;
+    }
+#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
     newptr = realloc_with_usize(ptr, size, &oldsize, &size);
     if (newptr == NULL) {
@@ -509,6 +550,13 @@ size_t zmalloc_usable_size(void *ptr) {
 void zfree(void *ptr) {
     if (ptr == NULL) return;
 
+#if defined(USE_JEMALLOC)
+    if (zmalloc_arena_flags) {
+        update_zmalloc_stat_free(zmalloc_size(ptr));
+        dallocx(ptr, zmalloc_arena_flags);
+        return;
+    }
+#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
     size_t oldsize;
     free_with_usize(ptr, &oldsize);
@@ -537,6 +585,15 @@ void zfree_usable(void *ptr, size_t *usable) {
         return;
     }
 
+#if defined(USE_JEMALLOC)
+    if (zmalloc_arena_flags) {
+        oldsize = zmalloc_size(ptr);
+        update_zmalloc_stat_free(oldsize);
+        dallocx(ptr, zmalloc_arena_flags);
+        if (usable) *usable = oldsize;
+        return;
+    }
+#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
     free_with_usize(ptr, &oldsize);
     update_zmalloc_stat_free(oldsize);

--- a/src/zmalloc.c
+++ b/src/zmalloc.c
@@ -72,10 +72,14 @@ void *je_malloc_with_usize(size_t size, size_t *usize);
 void *je_calloc_with_usize(size_t num, size_t size, size_t *usize);
 void *je_realloc_with_usize(void *ptr, size_t size, size_t *old_usize, size_t *new_usize);
 void je_free_with_usize(void *ptr, size_t *usize);
+void *je_mallocx_with_usize(size_t size, int flags, size_t *usize);
+void je_dallocx_with_usize(void *ptr, int flags, size_t *usize);
 #define malloc_with_usize(size,usize) je_malloc_with_usize(size,usize)
 #define calloc_with_usize(num,size,usize) je_calloc_with_usize(num,size,usize)
 #define realloc_with_usize(ptr,size,old_usize,new_usize) je_realloc_with_usize(ptr,size,old_usize,new_usize)
 #define free_with_usize(ptr,usize) je_free_with_usize(ptr,usize)
+#define mallocx_with_usize(size,flags,usize) je_mallocx_with_usize(size,flags,usize)
+#define dallocx_with_usize(ptr,flags,usize) je_dallocx_with_usize(ptr,flags,usize)
 #endif
 #endif
 
@@ -174,18 +178,10 @@ void *extend_to_usable(void *ptr, size_t size) {
 static inline void *ztrymalloc_usable_internal(size_t size, size_t *usable) {
     /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
     if (size >= SIZE_MAX/2) return NULL;
-#if defined(USE_JEMALLOC)
-    if (zmalloc_arena_flags) {
-        void *ptr = mallocx(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, zmalloc_arena_flags);
-        if (!ptr) return NULL;
-        size = zmalloc_size(ptr);
-        update_zmalloc_stat_alloc(size);
-        if (usable) *usable = size;
-        return ptr;
-    }
-#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
-    void *ptr = malloc_with_usize(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, &size);
+    void *ptr = zmalloc_arena_flags ?
+        mallocx_with_usize(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, zmalloc_arena_flags, &size) :
+        malloc_with_usize(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, &size);
 #else
     void *ptr = malloc(MALLOC_MIN_SIZE(size)+PREFIX_SIZE);
 #endif
@@ -315,18 +311,10 @@ void zfree_no_tcache(void *ptr) {
 static inline void *ztrycalloc_usable_internal(size_t size, size_t *usable) {
     /* Possible overflow, return NULL, so that the caller can panic or handle a failed allocation. */
     if (size >= SIZE_MAX/2) return NULL;
-#if defined(USE_JEMALLOC)
-    if (zmalloc_arena_flags) {
-        void *ptr = mallocx(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, zmalloc_arena_flags | MALLOCX_ZERO);
-        if (!ptr) return NULL;
-        size = zmalloc_size(ptr);
-        update_zmalloc_stat_alloc(size);
-        if (usable) *usable = size;
-        return ptr;
-    }
-#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
-    void *ptr = calloc_with_usize(1, MALLOC_MIN_SIZE(size)+PREFIX_SIZE, &size);
+    void *ptr = zmalloc_arena_flags ?
+        mallocx_with_usize(MALLOC_MIN_SIZE(size)+PREFIX_SIZE, zmalloc_arena_flags | MALLOCX_ZERO, &size) :
+        calloc_with_usize(1, MALLOC_MIN_SIZE(size)+PREFIX_SIZE, &size);
 #else
     void *ptr = calloc(1, MALLOC_MIN_SIZE(size)+PREFIX_SIZE);
 #endif
@@ -550,16 +538,13 @@ size_t zmalloc_usable_size(void *ptr) {
 void zfree(void *ptr) {
     if (ptr == NULL) return;
 
-#if defined(USE_JEMALLOC)
-    if (zmalloc_arena_flags) {
-        update_zmalloc_stat_free(zmalloc_size(ptr));
-        dallocx(ptr, zmalloc_arena_flags);
-        return;
-    }
-#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
     size_t oldsize;
-    free_with_usize(ptr, &oldsize);
+    if (zmalloc_arena_flags) {
+        dallocx_with_usize(ptr, zmalloc_arena_flags, &oldsize);
+    } else {
+        free_with_usize(ptr, &oldsize);
+    }
     update_zmalloc_stat_free(oldsize);
 #elif HAVE_MALLOC_SIZE
     update_zmalloc_stat_free(zmalloc_size(ptr));
@@ -585,17 +570,12 @@ void zfree_usable(void *ptr, size_t *usable) {
         return;
     }
 
-#if defined(USE_JEMALLOC)
-    if (zmalloc_arena_flags) {
-        oldsize = zmalloc_size(ptr);
-        update_zmalloc_stat_free(oldsize);
-        dallocx(ptr, zmalloc_arena_flags);
-        if (usable) *usable = oldsize;
-        return;
-    }
-#endif
 #ifdef HAVE_ALLOC_WITH_USIZE
-    free_with_usize(ptr, &oldsize);
+    if (zmalloc_arena_flags) {
+        dallocx_with_usize(ptr, zmalloc_arena_flags, &oldsize);
+    } else {
+        free_with_usize(ptr, &oldsize);
+    }
     update_zmalloc_stat_free(oldsize);
 #elif HAVE_MALLOC_SIZE
     update_zmalloc_stat_free(oldsize = zmalloc_size(ptr));

--- a/src/zmalloc.h
+++ b/src/zmalloc.h
@@ -127,6 +127,12 @@ void zlibc_free(void *ptr);
 void zmadvise_dontneed(void *ptr);
 
 #if defined(USE_JEMALLOC)
+/* Thread-local arena+tcache flags for KV data isolation.
+ * When non-zero, zmalloc/zcalloc/zrealloc route through mallocx/rallocx
+ * with these flags (MALLOCX_ARENA | MALLOCX_TCACHE).
+ * When zero (default), the standard malloc fast path is used. */
+extern __thread int zmalloc_arena_flags;
+
 void *zmalloc_with_flags(size_t size, int flags);
 void *zrealloc_with_flags(void *ptr, size_t size, int flags);
 void zfree_with_flags(void *ptr, int flags);


### PR DESCRIPTION
**before**
25348:M 26 Mar 2026 16:15:42.403 * Background saving started by pid 25954
25954:C 26 Mar 2026 16:16:51.826 * BGSAVE done, 34359040 keys saved, 0 keys skipped, 1020406705 bytes written.
25954:C 26 Mar 2026 16:16:51.829 * DB saved on disk
25954:C 26 Mar 2026 16:16:51.867 * Fork CoW for RDB: current 1231 MB, peak 1231 MB, average 974 MB
25348:M 26 Mar 2026 16:16:52.092 * Background saving terminated with success

**after**
26995:M 26 Mar 2026 16:29:27.148 * Background saving started by pid 27163
27163:C 26 Mar 2026 16:30:49.466 * BGSAVE done, 39251750 keys saved, 0 keys skipped, 1166755665 bytes written.
27163:C 26 Mar 2026 16:30:49.469 * DB saved on disk
27163:C 26 Mar 2026 16:30:49.476 * Fork CoW for RDB: current 135 MB, peak 801 MB, average 494 MB


# KV Arena Isolation — Reducing COW Overhead in Redis Child Processes

## 1. Background

When Redis performs RDB/AOF persistence, it forks a child process. The child shares physical pages with the parent via copy-on-write (COW). Because KV data and server infrastructure (networking, cron, replication, etc.) are allocated from the same jemalloc pages, writes by the parent to server data on a shared page trigger COW — even if the child has already finished dumping the KV data on that page.

**Goal**: Isolate KV memory allocations into dedicated jemalloc arenas so that the child process can free and purge the corresponding physical pages after dumping, preventing unnecessary COW.

## 2. Core Design

### 2.1 Arena + Tcache Grouping

Create **16 independent jemalloc arenas**, each with its own **dedicated tcache**:

```
arena_idx = slot % 16
```

- 16384 hash slots are evenly distributed across 16 arenas (~1024 slots per arena).
- In non-cluster mode all keys reside in slot 0, mapping to arena 0.
- Dedicated per-arena tcaches guarantee 100% isolation — tcache hits never return objects from a different arena.

### 2.2 Dual-Path Allocation

A thread-local variable `zmalloc_arena_flags` selects the allocation path:

```
zmalloc_arena_flags == 0  →  malloc/calloc/realloc/free   (default fast path, zero overhead)
zmalloc_arena_flags != 0  →  mallocx/rallocx/dallocx      (explicit arena + tcache)
```

**Non-KV allocations** (server startup, networking, cron, etc.) always take the default path — identical to the unmodified codebase.
**KV allocations** are routed through `mallocx` to the designated arena only during command execution.

### 2.3 Why mallocx Instead of thread.arena

| Approach | Isolation | Performance |
|---|---|---|
| `je_mallctl("thread.arena", ...)` | ❌ Stale tcache entries returned across arenas | malloc fast path |
| `thread.tcache.flush` + `thread.arena` | ✅ | ❌ Full flush of all bins on every switch |
| `mallocx(ARENA \| TCACHE)` shared tcache | ❌ tcache hits do not check arena ownership | mallocx overhead |
| **`mallocx(ARENA \| TCACHE)` per-arena tcache** | **✅ 100% isolation** | **mallocx overhead + tcache acceleration** |

### 2.4 Why 16 Arenas (modified 8 now due to performance)

- **More arenas** → finer purge granularity, smaller COW window; but more tcaches, each colder.
- **Fewer arenas** → hotter tcaches, better hit rate; but coarser purge granularity, larger COW window.

16 is a practical compromise, maybe 8. The main thread is single-threaded, so only 1 tcache is active at any time. The remaining 15 sit cold, consuming only static memory (~30–50 KB each, ~0.5–0.8 MB total) with zero CPU cost.

## 3. Implementation Details

### 3.1 Initialization (server.c — `kvArenaInit`)

```c
static unsigned kv_arenas[16];
static unsigned kv_tcaches[16];
static int      kv_arena_flags[16];  // precomputed MALLOCX_ARENA(a) | MALLOCX_TCACHE(t)

void kvArenaInit(void) {
    for (int i = 0; i < 16; i++) {
        je_mallctl("arenas.create", &kv_arenas[i], ...);
        je_mallctl("tcache.create", &kv_tcaches[i], ...);
        kv_arena_flags[i] = MALLOCX_ARENA(kv_arenas[i]) | MALLOCX_TCACHE(kv_tcaches[i]);
    }
}
```

### 3.2 Allocation / Deallocation Routing (zmalloc.c)

```c
__thread int zmalloc_arena_flags = 0;

// inside zmalloc
if (zmalloc_arena_flags) {
    ptr = mallocx(size, zmalloc_arena_flags);    // KV path
} else {
    ptr = malloc(size);                           // default fast path
}

// inside zfree
if (zmalloc_arena_flags) {
    dallocx(ptr, zmalloc_arena_flags);            // return to KV tcache
} else {
    free(ptr);                                    // default path
}
```

### 3.3 Command Execution Switch (server.c — `call()`)

```c
int old_arena_flags = zmalloc_arena_flags;
if (c->slot >= 0) {
    kvArenaSwitchToSlot(c->slot);   // zmalloc_arena_flags = kv_arena_flags[slot % 16]
}
c->cmd->proc(c);
zmalloc_arena_flags = old_arena_flags;  // restore (usually 0)
```

### 3.4 Eviction Path (evict.c) & Active Expire（TODO）&& Defragment（TODO）

`performEvictions()` is called before `call()`, when flags == 0. Explicit switching is required:

```c
if (bestslot >= 0) kvArenaSwitchToSlot(bestslot);
deleteEvictedKeyAndPropagate(db, keyobj, ...);
if (bestslot >= 0) kvArenaRestore();
```

### 3.5 RDB Child Process — Arena-Grouped Dump + Purge (rdb.c)

The child process iterates slots grouped by arena. After dumping all slots for an arena, it batch-frees and purges:

```c
for (int arena_idx = 0; arena_idx < 16; arena_idx++) {
    // 1. Dump: iterate all slots belonging to this arena, serialize to RDB
    for (int slot = arena_idx; slot < num_slots; slot += 16) {
        // rdbSaveKeyValuePair(...)
    }

    // 2. Batch free: switch to the arena's tcache so dallocx routes correctly
    kvArenaSwitchToSlot(arena_idx);
    for (int slot = arena_idx; slot < num_slots; slot += 16) {
        dictRelease(db->keys[slot]);
    }
    kvArenaRestore();

    // 3. Purge: madvise(MADV_DONTNEED) to release physical pages
    kvArenaPurge(arena_idx);
}
```

**Critical**: `kvArenaSwitchToSlot` must be called before the batch free. Otherwise `zfree → free()` routes through the default tcache, and freed objects remain cached there — preventing `kvArenaPurge` from reclaiming the corresponding physical pages.

maybe we can empty db and purge arena in a separate thread.

### 3.6 RDB Loading (rdb.c)

During loading, the arena is switched based on `RDB_OPCODE_SLOT_INFO` or `getKeySlot(key)`, ensuring loaded KV data lands in the correct arena:

```c
int saved_arena_flags = zmalloc_arena_flags;
// ...
// on SLOT_INFO opcode or when a key is read:
kvArenaSwitchToSlot(slot);
// load key + value ...
// after loading completes:
zmalloc_arena_flags = saved_arena_flags;
```

## 4. Known Limitations

### 4.1 Non-KV Allocations Inside call() Leak into KV Arenas

While flags are non-zero during `call()`, non-KV allocations such as reply buffers (`clientReplyBlock`) also route through `mallocx` into the KV arena.

**Impact is negligible**: `c->buf` is a fixed-size buffer pre-allocated when the client connection is created (outside `call()`). Dynamic `clientReplyBlock` allocation occurs only when `c->buf` overflows, and most command responses (OK, integers, short strings) fit within `c->buf`. The amount of non-KV data mixed in is trivial relative to KV data.

### 4.2 RAW-Encoded argv Allocated in the Default Arena

All command argument SDS strings are allocated in `processMultibulkBuffer` (before `call()`, when `zmalloc_arena_flags == 0`), placing them in the default arena:

- **≥ 32 KB**: Zero-copy — `c->querybuf` is transferred directly to `argv`, no copy made.
- **45 bytes – 32 KB**: `createStringObject` copies the SDS, but the copy happens while flags == 0, so the new SDS is also in the default arena.
- **≤ 44 bytes**: `tryObjectEncoding` inside `call()` (flags already set) converts to EMBSTR/INT encoding with a fresh allocation — **not affected**.

**When a write command (e.g., SET) executes, `setGenericCommand` stores the `argv[2]` robj directly into the DB (`incrRefCount`, no copy). Therefore **all OBJ_ENCODING_RAW string values (> 44 bytes) have their underlying SDS in the default arena, not in the KV arena**.**


**Optimization — Hybrid Threshold Strategy**:

Different strategies based on value size, balancing memcpy overhead against isolation effectiveness:

| Size | Encoding | Strategy | Rationale |
|------|----------|----------|-----------|
| ≤ 44 bytes | EMBSTR/INT | No action | `tryObjectEncoding` re-allocates inside `call()`, already in KV arena |
| 45 bytes – 4 KB | RAW | memcpy to KV arena | Copy cost is trivial, reclaimed via arena purge |
| ≥ 4 KB | RAW | No copy, stays in default arena | Child process uses `dismissObject` → `madvise(MADV_DONTNEED)` to release physical pages directly |

**Why ≥ 4 KB values don't need copying**:
- jemalloc uses large size class for ≥ 4 KB allocations, each occupying dedicated page runs
- `madvise(MADV_DONTNEED)` can precisely release these standalone pages, independent of arena isolation
- The child process already has a complete dismiss flow (`rdbSaveRio` / `rewriteAppendOnlyFileRio` calls `dismissObject` after serializing each key)
- `dismissMemory` has a built-in threshold guard (`size_hint <= page_size/2` → skip), naturally aligned with the 4 KB threshold

```c
// In SET family write path (e.g., setGenericCommand), before storing into DB
if (zmalloc_arena_flags && val->encoding == OBJ_ENCODING_RAW) {
    size_t len = sdslen(val->ptr);
    if (len > OBJ_ENCODING_EMBSTR_SIZE_LIMIT && len < 4096) {
        sds old = val->ptr;
        val->ptr = sdsnewlen(old, sdslen(old));  // KV arena
        sdsfree(old);                              // free from default arena
    }
    // ≥ 4096: no copy, handled by child process dismissMemory
}

```

The memcpy cost for the 45-byte to 4 KB range is negligible; values ≥ 4 KB completely avoid copying, with the child process `dismissMemory` mechanism as the safety net.

**or maybe we just ignore `45 bytes – 4 KB` string objects, i.e. allow the CoW of them**

## 5. Modified Files

| File | Changes |
|---|---|
| `src/zmalloc.h` | Declare `zmalloc_arena_flags` TLS variable |
| `src/zmalloc.c` | Add flags branch to `ztrymalloc`/`ztrycalloc`/`ztryrealloc`/`zfree`/`zfree_usable` |
| `src/server.h` | Declare `KV_ARENA_COUNT`, `kvArenaInit`/`Switch`/`Restore`/`Purge` |
| `src/server.c` | Implement arena/tcache initialization; arena switch in `call()` |
| `src/evict.c` | Switch to bestslot's arena during eviction |
| `src/rdb.c` | Arena-grouped dump + purge in child process; per-slot arena switch during load |

